### PR TITLE
MINOR: improving examples, adding German example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is based on another project called [RAKE-PHP](https://github.com/Ri
 In M. W. Berry & J. Kogan (Eds.), Text Mining: Theory and Applications: John Wiley & Sons.*
 
 
-This particular package intends to include the following benefits over the original[RAKE-PHP](https://github.com/Richdark/RAKE-PHP) package:
+This particular package intends to include the following benefits over the original [RAKE-PHP](https://github.com/Richdark/RAKE-PHP) package:
 
 1. Add [PSR-2](http://www.php-fig.org/psr/psr-2/) coding standards.
 2. Implement [PSR-4](http://www.php-fig.org/psr/psr-4/) in order to be [Composer](https://getcomposer.org) installable.

--- a/examples/de_DE_example.php
+++ b/examples/de_DE_example.php
@@ -1,7 +1,7 @@
 <?php
 
 // To run this example from the command line:
-// php ./examples/en_US_example.php "Some example text"
+// php ./examples/de_DE_example.php "Dein Beispielsatz"
 
 require '../vendor/autoload.php';
 
@@ -9,15 +9,15 @@ use DonatelloZa\RakePlus\RakePlus;
 
 if ($argc < 2) {
     echo "Please specify the text you would like to be parsed, e.g.:\n";
-    echo "php ./examples/en_US_example.php \"Some example text from which I would like to extract keywords\"\n";
+    echo "php ./examples/de_DE_example.php \"Ein Beispieltext aus dem du die Schlüsselwörter extrahieren möchtest.\"\n";
     exit(1);
 }
 
-$keywords = RakePlus::create($argv[1])->keywords();
+$keywords = RakePlus::create($argv[1], 'de_DE')->keywords();
 print "The keywords for \"{$argv[1]}\" is:\n";
 print_r($keywords);
 
-$phrases = RakePlus::create($argv[1])->get();
+$phrases = RakePlus::create($argv[1], 'de_DE')->get();
 print "The phrases for \"{$argv[1]}\" is:\n";
 print_r($phrases);
 

--- a/examples/es_AR_example.php
+++ b/examples/es_AR_example.php
@@ -3,7 +3,7 @@
 // Para ejecutar este ejemplo desde la línea de comando.:
 // php ./examples/es_AR_example.php "Algun texto de ejemplo"
 
-require 'vendor/autoload.php';
+require '../vendor/autoload.php';
 
 use DonatelloZa\RakePlus\RakePlus;
 
@@ -14,9 +14,9 @@ if ($argc < 2) {
 }
 
 $keywords = RakePlus::create($argv[1], 'es_AR')->keywords();
-print "Resultados de palabras clave: {$argv[1]}\n";
+print "Resultados de palabras clave: \"{$argv[1]}\"\n";
 print_r($keywords);
 
 $phrases = RakePlus::create($argv[1], 'es_AR')->get();
-print "Resultados de la frase: {$argv[1]}\n";
+print "Resultados de la frase: \"{$argv[1]}\"\n";
 print_r($phrases);

--- a/examples/fr_FR_example.php
+++ b/examples/fr_FR_example.php
@@ -3,7 +3,7 @@
 // Pour exécuter cet exemple à partir de la ligne de commande
 // php ./examples/fr_FR_example.php "Un exemple de texte"
 
-require 'vendor/autoload.php';
+require '../vendor/autoload.php';
 
 use DonatelloZa\RakePlus\RakePlus;
 
@@ -14,9 +14,9 @@ if ($argc < 2) {
 }
 
 $keywords = RakePlus::create($argv[1], 'fr_FR')->keywords();
-print "Résultats de mots clés: {$argv[1]}\n";
+print "Résultats de mots clés: \"{$argv[1]}\"\n";
 print_r($keywords);
 
 $phrases = RakePlus::create($argv[1], 'fr_FR')->get();
-print "Résultats de la phrase: {$argv[1]}\n";
+print "Résultats de la phrase: \"{$argv[1]}\"\n";
 print_r($phrases);

--- a/examples/pt_BR_example.php
+++ b/examples/pt_BR_example.php
@@ -3,7 +3,7 @@
 // Para ejecutar este ejemplo desde la línea de comando.:
 // php ./examples/es_AR_example.php "Algun texto de ejemplo"
 
-require 'vendor/autoload.php';
+require '../vendor/autoload.php';
 
 use DonatelloZa\RakePlus\RakePlus;
 
@@ -14,9 +14,9 @@ if ($argc < 2) {
 }
 
 $keywords = RakePlus::create($argv[1], 'pt_BR')->keywords();
-print "Resultados de palabras clave: {$argv[1]}\n";
+print "Resultados de palabras clave: \"{$argv[1]}\"\n";
 print_r($keywords);
 
 $phrases = RakePlus::create($argv[1], 'pt_BR')->scores();
-print "Resultados de la frase: {$argv[1]}\n";
+print "Resultados de la frase: \"{$argv[1]}\"\n";
 print_r($phrases);


### PR DESCRIPTION
Hey @Donatello-za,

I've been trying out how come keywords are parsed using the script in the example folder. I've noticed a few things along the way. Here are a few minor improvements for the examples:

 - Tweaking path so someone can clone the repo, install composer dependencies and play directly with the examples (from ```vendor/autoload.php``` to ```../vendor/autoload.php```)
 - Improving readability a bit
 - Adding German example in

I hope this works for you.

Cheers,
Peter