### PR TITLE
Adding support for confusables charachters

### DIFF
--- a/src/LangParseOptions.php
+++ b/src/LangParseOptions.php
@@ -37,7 +37,7 @@ class LangParseOptions implements ILangParseOptions
                 break;
 
             default:
-                $this->setSentenceRegEx('[.!?,;:\t\"\(\)]');
+                $this->setSentenceRegEx('[.!?,;:\t\"\“\”\(\)]');
         }
     }
 


### PR DESCRIPTION
I stumbled across a slightly strange behaviour. 

Some texts uses not the default double quotation mark, which are yet not recognized by the used sentence regex.
See https://util.unicode.org/UnicodeJsps/confusables.jsp?a=%22&r=None fore more charachters which are similar to the default double quatation mark.  This also matters for the single quoatation mark.

For me there are three possibilities to handle those cases:  
a) add all similar characters to the regex.  
b) use a general method to convert all similar looking characters to the "default" version.  
c) ignore those special cases.   

In this pull request I started with a). But I'm pretty sure you know how to do it right.