### PR TITLE
Some enhancements to 2.0.0

### DIFF
--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -158,6 +158,10 @@ class RakePlus
         return $this;
     }
 
+    /**
+     * @param array|string|AbstractStopwordProvider $stopwords
+     * @return void
+     */
     protected function initPattern($stopwords): void
     {
         $this->validateStopwords($stopwords);

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -143,6 +143,23 @@ class RakePlus
             return $this;
         }
 
+        $this->initPattern($stopwords);
+
+        if ($this->mb_support) {
+            $sentences = $this->splitSentencesMb($text);
+            $phrases = $this->getPhrasesMb($sentences, $this->pattern);
+        } else {
+            $sentences = $this->splitSentences($text);
+            $phrases = $this->getPhrases($sentences, $this->pattern);
+        }
+
+        $word_scores = $this->calcWordScores($phrases);
+        $this->phrase_scores = $this->calcPhraseScores($phrases, $word_scores);
+        return $this;
+    }
+
+    protected function initPattern($stopwords): void
+    {
         $this->validateStopwords($stopwords);
 
         if (is_array($stopwords)) {
@@ -181,21 +198,7 @@ class RakePlus
 
         if (is_a($stopwords, AbstractStopwordProvider::class, false)) {
             $this->pattern = $stopwords->pattern();
-        } else {
-            throw new InvalidArgumentException('Invalid stopwords list provided for RakePlus.');
         }
-
-        if ($this->mb_support) {
-            $sentences = $this->splitSentencesMb($text);
-            $phrases = $this->getPhrasesMb($sentences, $this->pattern);
-        } else {
-            $sentences = $this->splitSentences($text);
-            $phrases = $this->getPhrases($sentences, $this->pattern);
-        }
-
-        $word_scores = $this->calcWordScores($phrases);
-        $this->phrase_scores = $this->calcPhraseScores($phrases, $word_scores);
-        return $this;
     }
 
     protected function validateStopwords($stopwords): void

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -460,7 +460,9 @@ class RakePlus
      */
     private function splitPhraseIntoWords(string $phrase): array
     {
-        return array_filter(preg_split('/\W+/u', $phrase, -1, PREG_SPLIT_NO_EMPTY), function ($word) {
+        $splitPhrase = preg_split('/\W+/u', $phrase, -1, PREG_SPLIT_NO_EMPTY);
+
+        return array_filter($splitPhrase, static function ($word) {
             return !is_numeric($word);
         });
     }

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -340,10 +340,10 @@ class RakePlus
             $phrases_temp = preg_replace($pattern, '|', $sentence);
             $phrases = explode('|', $phrases_temp);
             foreach ($phrases as $phrase) {
-                $phrase = mb_strtolower(trim($phrase));
+                $phrase = strtolower(trim($phrase));
                 if (!empty($phrase)) {
                     if (!$this->filter_numerics || !is_numeric($phrase)) {
-                        if ($this->min_length === 0 || mb_strlen($phrase) >= $this->min_length) {
+                        if ($this->min_length === 0 || strlen($phrase) >= $this->min_length) {
                             $results[] = $phrase;
                         }
                     }

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -186,9 +186,26 @@ class RakePlus
 
     protected function initPatternFromString($stopwords): void
     {
-        if (is_null($this->pattern) || ($this->language != $stopwords)) {
-            $extension = mb_strtolower(pathinfo($stopwords, PATHINFO_EXTENSION));
-            if (empty($extension)) {
+        if (!is_null($this->pattern) && ($this->language == $stopwords)) {
+            return;
+        }
+
+        $extension = mb_strtolower(pathinfo($stopwords, PATHINFO_EXTENSION));
+
+        switch ($extension) {
+            case 'pattern':
+                $this->language = $stopwords;
+                $this->language_file = $stopwords;
+                $this->pattern = StopwordsPatternFile::create($this->language_file)->pattern();
+                break;
+
+            case 'php':
+                $this->language = $stopwords;
+                $this->language_file = $stopwords;
+                $this->pattern = StopwordsPHP::create($this->language_file)->pattern();
+                break;
+
+            default:
                 // First try the .pattern file
                 $this->language_file = StopwordsPatternFile::languageFile($stopwords);
                 if (file_exists($this->language_file)) {
@@ -198,20 +215,6 @@ class RakePlus
                     $this->pattern = StopwordsPHP::create($this->language_file)->pattern();
                 }
                 $this->language = $stopwords;
-            } else {
-                if ($extension == 'pattern') {
-                    $this->language = $stopwords;
-                    $this->language_file = $stopwords;
-                    $this->pattern = StopwordsPatternFile::create($this->language_file)->pattern();
-                } else {
-                    if ($extension == 'php') {
-                        $language_file = $stopwords;
-                        $this->language = $stopwords;
-                        $this->language_file = $language_file;
-                        $this->pattern = StopwordsPHP::create($this->language_file)->pattern();
-                    }
-                }
-            }
         }
     }
 

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -154,7 +154,7 @@ class RakePlus
         }
 
         $word_scores = $this->calculateWordScores($phrases);
-        $this->phrase_scores = $this->calcPhraseScores($phrases, $word_scores);
+        $this->phrase_scores = $this->calculatePhraseScores($phrases, $word_scores);
         return $this;
     }
 
@@ -458,7 +458,7 @@ class RakePlus
      *
      * @return array
      */
-    private function calcPhraseScores(array $phrases, array $scores): array
+    private function calculatePhraseScores(array $phrases, array $scores): array
     {
         $keywords = [];
 

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -139,7 +139,7 @@ class RakePlus
      */
     public function extract(string $text, $stopwords = 'en_US'): RakePlus
     {
-        if ($text === '') {
+        if (trim($text) === '') {
             return $this;
         }
 

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -164,19 +164,22 @@ class RakePlus
      */
     protected function initPattern($stopwords): void
     {
-        $this->validateStopwords($stopwords);
-
         if (is_array($stopwords)) {
             $this->initPatternFromArray($stopwords);
+            return;
         }
 
         if (is_string($stopwords)) {
             $this->initPatternFromString($stopwords);
+            return;
         }
 
-        if (is_a($stopwords, AbstractStopwordProvider::class, false)) {
+        if (is_object($stopwords) && is_a($stopwords, AbstractStopwordProvider::class, false)) {
             $this->initPatternFromProvider($stopwords);
+            return;
         }
+
+        throw new InvalidArgumentException('Invalid stopwords list provided for RakePlus.');
     }
 
     protected function initPatternFromArray($stopwords): void
@@ -221,18 +224,6 @@ class RakePlus
     protected function initPatternFromProvider($stopwords): void
     {
         $this->pattern = $stopwords->pattern();
-    }
-
-    protected function validateStopwords($stopwords): void
-    {
-        if (
-            !is_array($stopwords)
-            && !is_string($stopwords)
-            && !is_object($stopwords)
-            && !is_a($stopwords, AbstractStopwordProvider::class, false)
-        ) {
-            throw new InvalidArgumentException('Invalid stopwords list provided for RakePlus.');
-        }
     }
 
     /**

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -153,7 +153,7 @@ class RakePlus
             $phrases = $this->getPhrases($sentences, $this->pattern);
         }
 
-        $word_scores = $this->calcWordScores($phrases);
+        $word_scores = $this->calculateWordScores($phrases);
         $this->phrase_scores = $this->calcPhraseScores($phrases, $word_scores);
         return $this;
     }
@@ -419,7 +419,7 @@ class RakePlus
      *
      * @return array
      */
-    private function calcWordScores(array $phrases): array
+    private function calculateWordScores(array $phrases): array
     {
         $frequencies = [];
         $degrees = [];

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -347,8 +347,10 @@ class RakePlus
      */
     private function splitSentences(string $text): array
     {
-        return preg_split('/' . $this->sentence_regex . '/',
-            preg_replace('/' . $this->line_terminator . '/', ' ', $text));
+        return preg_split(
+            '/' . $this->sentence_regex . '/',
+            preg_replace('/' . $this->line_terminator . '/', ' ', $text),
+        );
     }
 
     /**
@@ -360,8 +362,10 @@ class RakePlus
      */
     private function splitSentencesMb(string $text): array
     {
-        return mb_split($this->sentence_regex,
-            mb_ereg_replace($this->line_terminator, ' ', $text));
+        return mb_split(
+            $this->sentence_regex,
+            mb_ereg_replace($this->line_terminator, ' ', $text),
+        );
     }
 
     /**

--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -189,6 +189,7 @@ class RakePlus
 
     protected function initPatternFromString($stopwords): void
     {
+        // @note ideally, this conditional should be called somehow
         if (!is_null($this->pattern) && ($this->language == $stopwords)) {
             return;
         }


### PR DESCRIPTION
Hello again,

Here are some enhancements for the 2.0.0 milestone. This PR:
- fixes the usage of `mb_` functions in the `getPhrases` method because it is called only when the `mb_string` extension is mission (However, I think, these methods may be even removed `splitSentences` and `getPhrases` or merged with `splitSentencesMb` and `getPhrasesMb` because the package requires the mbstring extension in the `composer.json` and it seems that it is impossible to use it without this extension. I see only one option, when the package is installed with -W option). Or, if you want to keep them just in case, I would recommend to update their logic and conduct the check of the extension inside the methods (not outside). I can show what do I mean by that.
- simplifies the `extract` method by extracting different initPattern methods
- some formatting improvements
