### PR TITLE
Revert back an init min value exception

### DIFF
--- a/src/RakePlus.php
+++ b/src/RakePlus.php
@@ -70,7 +70,11 @@ class RakePlus
 
     protected function initMinLength(int $min_length): void
     {
-        $this->min_length = max($min_length, 0);
+        if ($min_length < 0) {
+            throw new InvalidArgumentException('Minimum phrase length must be greater than or equal to 0.');
+        }
+
+        $this->min_length = $min_length;
     }
 
     protected function initFilterNumerics($filter_numerics): void
@@ -493,9 +497,13 @@ class RakePlus
      */
     public function setMinLength(int $min_length): RakePlus
     {
-        // @note there is no need to throw an exception in runtime to me
-        // the exception can be caught and a default value used instead
-        $this->initMinLength($min_length);
+        $default_min_length = 0;
+
+        try {
+            $this->initMinLength($min_length);
+        } catch (InvalidArgumentException $e) {
+            $this->initMinLength($default_min_length);
+        }
 
         return $this;
     }

--- a/tests/RakePlusTest.php
+++ b/tests/RakePlusTest.php
@@ -29,6 +29,14 @@ class RakePlusTest extends TestCase
         RakePlus::create("Hello World", "blah");
     }
 
+    public function testInvalidMinLength()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('length must be');
+
+        RakePlus::create("Hello World", 'en_US', -1);
+    }
+
     public function testNullLanguage()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
In the continuation to [this discussion](https://github.com/Donatello-za/rake-php-plus/commit/c0bf999b99e2c561aca93f9317eb7e813b62f075#r152324533).

This PR reverts back the init min value exception but keep exceptionless the `setMinLength` method.